### PR TITLE
Issue 303

### DIFF
--- a/cc/css/app.css
+++ b/cc/css/app.css
@@ -2459,13 +2459,22 @@ h1.entry-title {
                 -ms-flex: 0 1 40%;
                     flex: 0 1 40%; } }
         .our-programs .inner-list ul li img {
-          height: 100%; }
+          display: block;
+          width: 77px;
+          height: auto;
+          -webkit-flex-shrink: 0;
+              -ms-flex-negative: 0;
+                  flex-shrink: 0; }
         .our-programs .inner-list ul li .program-title {
           display: block;
           color: white;
           font-weight: bold;
           font-size: 2.8rem;
-          margin-left: 30px; }
+          margin-left: 30px;
+          -webkit-box-flex: 1;
+          -webkit-flex-grow: 1;
+              -ms-flex-positive: 1;
+                  flex-grow: 1; }
 
 .author-wrapper {
   margin-bottom: 20px; }

--- a/cc/css/app.css
+++ b/cc/css/app.css
@@ -2401,7 +2401,7 @@ h1.entry-title {
 .our-programs {
   clear: both;
   background-color: #00B5DA;
-  padding: 55px 10px; }
+  padding: 55px 20px; }
   @media (min-width: 44.375em) {
     .our-programs {
       padding: 55px; } }
@@ -2430,7 +2430,9 @@ h1.entry-title {
       list-style: none;
       -webkit-align-content: stretch;
           -ms-flex-line-pack: stretch;
-              align-content: stretch; }
+              align-content: stretch;
+      margin: 0;
+      padding: 0; }
       .our-programs .inner-list ul li {
         display: -webkit-box;
         display: -webkit-flex;
@@ -2469,8 +2471,8 @@ h1.entry-title {
           display: block;
           color: white;
           font-weight: bold;
-          font-size: 2.8rem;
-          margin-left: 30px;
+          font-size: 2.4rem;
+          margin-left: 20px;
           -webkit-box-flex: 1;
           -webkit-flex-grow: 1;
               -ms-flex-positive: 1;

--- a/cc/scss/components/_pages.scss
+++ b/cc/scss/components/_pages.scss
@@ -174,7 +174,7 @@ h1.entry-title {
 .our-programs {
   clear: both;
   background-color: $blue-light;
-  padding: 55px 10px;
+  padding: 55px 20px;
 
   @include breakpoint($tablet-sm-layout) {
     padding: 55px;
@@ -194,6 +194,8 @@ h1.entry-title {
       flex-direction: row;
       list-style: none;
       align-content: stretch;
+      margin: 0;
+      padding: 0;
       li {
         display: flex;
         align-items: center;
@@ -216,8 +218,8 @@ h1.entry-title {
           display:block;
           color:white;
           font-weight: bold;
-          font-size: px2rem($fz-xlg);
-          margin-left: 30px;
+          font-size: px2rem($fz-lg);
+          margin-left: 20px;
           flex-grow: 1;
         }
       }

--- a/cc/scss/components/_pages.scss
+++ b/cc/scss/components/_pages.scss
@@ -198,7 +198,7 @@ h1.entry-title {
         display: flex;
         align-items: center;
         justify-content: flex-start;
-        color:white;
+        color: white;
         flex: 0 1 100%;
         font-weight: bold;
         font-size: px2rem($fz-xlg);
@@ -207,7 +207,10 @@ h1.entry-title {
           flex: 0 1 40%;
         }
         img {
-          height: 100%; //firefox bug
+          display: block;
+          width: 77px;
+          height: auto;
+          flex-shrink: 0;
         }
         .program-title{
           display:block;
@@ -215,7 +218,7 @@ h1.entry-title {
           font-weight: bold;
           font-size: px2rem($fz-xlg);
           margin-left: 30px;
-
+          flex-grow: 1;
         }
       }
     }


### PR DESCRIPTION
This fixes an issue reported in https://github.com/creativecommons/creativecommons.org/issues/303 where icons at https://creativecommons.org/use-remix/ would wrongly give up space to their labels.
