### PR TITLE
Tweak search field appearance for mobile

### DIFF
--- a/cc/css/app.css
+++ b/cc/css/app.css
@@ -294,7 +294,9 @@ input[type="submit"] {
     background-color: #F2F2F2;
     border-color: #F2F2F2;
     padding-bottom: 0;
-    padding-top: 0; }
+    padding-top: 0;
+    margin: 0;
+    -webkit-appearance: none; }
   body.layout-mobile .search-form .search-field {
     display: none; }
   @media (min-width: 44.375em) {
@@ -1422,7 +1424,7 @@ body.admin-bar .site-header.sticky {
             -ms-flex-positive: 1;
                 flex-grow: 1; }
       .cc-footer .column.cc-footer-main .cc-footer-links .search-form.expanded .search-field {
-        min-width: 180px; }
+        min-width: 160px; }
     @media (min-width: 44.375em) {
       .cc-footer .column.cc-footer-main {
         -webkit-box-ordinal-group: 1;

--- a/cc/scss/base/_elements.scss
+++ b/cc/scss/base/_elements.scss
@@ -177,6 +177,8 @@ input[type="submit"] {
       border-color: #F2F2F2;
       padding-bottom: 0;
       padding-top: 0;
+      margin: 0;
+      -webkit-appearance: none;
     }
   }
 

--- a/cc/scss/base/_layout.scss
+++ b/cc/scss/base/_layout.scss
@@ -388,7 +388,7 @@ body.admin-bar .site-header.sticky {
 
       .search-form.expanded {
         .search-field {
-          min-width: 180px;
+          min-width: 160px;
         }
       }
     }


### PR DESCRIPTION
This disables Webkit's funny rendering for the search input, and decreases its (alas, still weirdly hard-coded) min-width to fit better on small screens.

That's the issue I'd discovered over here trying to reproduce the original problem: https://github.com/creativecommons/creativecommons.org/issues/289
