### PR TITLE
Add global menu support for creativecommons.org

### DIFF
--- a/cc/functions.php
+++ b/cc/functions.php
@@ -120,6 +120,7 @@ function cc_register_menu() {
     'mobile' => __( 'Mobile Menu' ),
     'secondary' => __( 'Secondary Menu' ),
     'footer-links'  => __( 'Footer Links' ),
+    'global-menu'  => __( 'Global Menu' ),
   ) );
 }
 add_action('init', 'cc_register_menu');
@@ -301,34 +302,34 @@ add_filter( 'gform_require_login_pre_download', '__return_true' );
 // Akismet is too eager to mark these as spam - RobM
 add_filter( 'gform_akismet_enabled_17' , '__return_false' );
 
-add_action( 'wp_footer', 'cc_add_google_marketing_script' );
-
-function cc_add_google_marketing_script() {
-  ?>
-  <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','__gaTracker');
-
-      __gaTracker('create', 'UA-2010376-1', 'auto');
-      __gaTracker('set', 'forceSSL', true);
-      __gaTracker('send','pageview');
-  </script>
-  <!-- Google Tag Manager -->
-  <script type="text/javascript">
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-KP4CRCM');
-  </script>
-  <!-- End Google Tag Manager -->
-  <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KP4CRCM"
-  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager (noscript) -->
-  <?php
+class CC_Org_Filters {
+  public static function get_main_menu() {
+    if ( false === ( $global_menu_items = get_transient( 'global_menu_items' ) ) ) {
+      $menu_locations = get_nav_menu_locations();
+      $global_menu = wp_get_nav_menu_object($menu_locations['global-menu']);
+      if ( !empty( $global_menu ) ) {
+        $global_menu_items = wp_get_nav_menu_items($global_menu);
+        set_transient( 'global_menu_items', $global_menu_items, 1 * HOUR_IN_SECONDS );
+      }
+    }
+    return $global_menu_items;
+  }
+  public static function set_custom_menu_endpoint() {
+    register_rest_route( 'ccglobal', '/menu', array(
+      'methods' => 'GET',
+      'callback' => array('CC_Org_Filters','get_main_menu'),
+	  ));
+  }
+  /**
+   * Remove Global menu transient
+   *
+   * @param int $nav_menu_selected_id
+   * @return void
+   */
+  function remove_global_menu_transient($nav_menu_selected_id) {
+    delete_transient( 'global_menu_items' );
+  }
 }
 
-?>
+add_action( 'wp_update_nav_menu', array( 'CC_Org_Filters', 'remove_global_menu_transient' ) );
+add_action( 'rest_api_init', array( 'CC_Org_Filters', 'set_custom_menu_endpoint') );


### PR DESCRIPTION
## Description
This PR add support for managing the global menu from the current theme at creativecommons.org. this will allow to query the current website in order to use global menu. This support includes
 - add menu location for global menu
 - Custom endpoint in WP-API to retrieve menu elements 
- Use of transient API to cache the results for 1 hour

Non-related: removed tag manager script and analytics to rollback to monster insights plugin

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
