### PR TITLE
filter wp api to restrict users endpoint

### DIFF
--- a/cc/functions.php
+++ b/cc/functions.php
@@ -397,3 +397,32 @@ function cc_donation_banner_custom_confirmation( $confirmation, $form, $entry, $
 	wp_redirect( $url );
 	exit();
 }
+
+/**
+ * Wrap an existing default callback passed in parameter and create
+ * a new permission callback introducing preliminary checks and
+ * falling-back on the default callback in case of success.
+ */
+add_filter( 'rest_endpoints', 'api_users_endpoint_force_auth' );
+function permission_callback_hardener( $existing_callback ) {
+	return function ( $request ) use ( $existing_callback ) {
+		if ( ! current_user_can( 'list_users' ) ) {
+				return new WP_Error(
+					'rest_user_cannot_view',
+					__( 'Sorry, you are not allowed to access users.' ),
+					[ 'status' => rest_authorization_required_code() ]
+				);
+		}
+
+			return $existing_callback( $request );
+	};
+}
+function api_users_endpoint_force_auth( $endpoints ) {
+	$users_get_route                        = &$endpoints['/wp/v2/users'][0];
+	$users_get_route['permission_callback'] = permission_callback_hardener( $users_get_route['permission_callback'] );
+
+	$user_get_route                        = &$endpoints['/wp/v2/users/(?P<id>[\d]+)'][0];
+	$user_get_route['permission_callback'] = permission_callback_hardener( $user_get_route['permission_callback'] );
+
+	return $endpoints;
+}


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/753 by @TimidRobot 

## Description
This PR restricts the user's endpoint from WordPress API only for admin users, this should avoid external queries but there would be no problem with Gutenberg's internal queries.
Also, we can't entirely disable the API rest because it's used by the Global Menu and the Widget which shows CC.org blog entries

## Screenshots
![Screen Shot 2021-01-21 at 4 44 09 PM](https://user-images.githubusercontent.com/894708/105403748-eb787a80-5c07-11eb-86aa-e6b2f8174ffb.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
